### PR TITLE
Update API url to new domain

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ class Client {
 
     var default_http = {
       User_Agent: `dangerous-discord.js/v${packageDotJson.version}`,
-      apiURL: "discord.drivet.xyz/api/",
+      apiURL: "dangerousdiscord.com/api/",
     };
     this.http = options.http ? options.http : default_http;
     this.httpInstance = axios.create({


### PR DESCRIPTION
discord.drivet.xyz will redirect traffic to dangerousdiscord.com starting March 20th, and it eventually breaks the API on the old url